### PR TITLE
Add support for Billund

### DIFF
--- a/pyrenoweb/const.py
+++ b/pyrenoweb/const.py
@@ -244,6 +244,7 @@ MUNICIPALITIES_LIST = {
     "Aalborg": "aalborg",
     "Albertslund": "albertslund",
     "Allerød": "allerod",
+    "Billund": "billund",
     "Brøndby": "brondby",
     "Brønderslev": "bronderslev",
     "Dragør": "dragoer",


### PR DESCRIPTION
Added Billund municipality to the list, not sure if there is any particular reasons its not already supported as it seems to be used on borger.dk through renoweb (https://billund.renoweb.dk/Legacy/selvbetjening/mit_affald.aspx)